### PR TITLE
feat: key not from file & other improvements

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+      - run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
       - run: cargo clippy --workspace --all-features --all-targets -- -D warnings
       - run: cargo test --workspace --all-features --all-targets
       - run: cargo fmt -- --check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,13 @@
+name: Cargo checks
+on:
+  push:
+  pull_request:
+jobs:
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+      - run: cargo clippy --workspace --all-features --all-targets -- -D warnings
+      - run: cargo test --workspace --all-features --all-targets
+      - run: cargo fmt -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ serde = "1"
 serde_json = "1"
 serde_derive = "1"
 dirs = "5.0.1"
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.12.4", features = ["json"] }
 chrono = "0.4.31"
 base64 = "0.21.3"
 ring = "0.16.20"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,4 +34,4 @@ env_logger = "0.10.0"
 
 [features]
 app-blocking = ["dep:futures"]
-token-watcher = ["dep:tokio", "dep:async-trait", "dep:log"]
+token-watcher = ["dep:async-trait", "dep:log"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ ring = "0.16.20"
 thiserror = "1.0.48"
 anyhow = "1.0.40"
 futures = { version = "0.3", features = ["executor"], optional = true }
-tokio = { version = "1.33.0", optional = true }
+tokio = { version = "1.33.0", features = ["test-util", "sync"] }
 log = { version = "0.4", optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "HTTP Client for Google OAuth2"
 name = "gauth"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Simon Makarski <code@makarski.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -29,7 +29,7 @@ log = { version = "0.4", optional = true }
 
 [dev-dependencies]
 mockito = "1.2.0"
-tokio = { version = "1.33.0", features = ["test-util"] }
+tokio = { version = "1.33.0", features = ["test-util", "rt", "macros", "rt-multi-thread"] }
 env_logger = "0.10.0"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The library supports the following Google Auth flows:
 
 ```toml
 [dependencies]
-gauth = "0.8"
+gauth = "0.9"
 ```
 
 #### OAuth2
@@ -45,7 +45,7 @@ It is also possible to make a **blocking call** to retrieve an access token. Thi
 
 ```
 [dependencies]
-gauth = { version = "0.8", features = ["app-blocking"] }
+gauth = { version = "0.9", features = ["app-blocking"] }
 ```
 
 ```rust,no_run
@@ -123,7 +123,7 @@ To resolve this, we adopted an experimental approach by developing a `token_prov
 
 ```
 [dependencies]
-gauth = { version = "0.8", features = ["token-watcher"] }
+gauth = { version = "0.9", features = ["token-watcher"] }
 ```
 
 ```rust,no_run

--- a/examples/async_token_provider.rs
+++ b/examples/async_token_provider.rs
@@ -12,8 +12,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .nth(1)
         .expect("Provide a path to the service account key file");
 
-    let service_account =
-        ServiceAccount::from_file(&keypath, vec!["https://www.googleapis.com/auth/pubsub"]);
+    let service_account = ServiceAccount::from_file(&keypath)
+        .unwrap()
+        .scopes(vec!["https://www.googleapis.com/auth/pubsub"])
+        .build()
+        .unwrap();
 
     let tp = AsyncTokenProvider::new(service_account).with_interval(5);
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -260,7 +260,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_access_token_success() {
-        let mut google = mockito::Server::new();
+        let mut google = mockito::Server::new_async().await;
         let google_host = google.url();
 
         google

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -90,7 +90,7 @@ impl Auth {
 
     /// App_name can be used to override the default app name
     pub fn app_name(mut self, app_name: &str) -> Self {
-        self.app_name = app_name.to_owned();
+        app_name.clone_into(&mut self.app_name);
         self
     }
 

--- a/src/serv_account/errors.rs
+++ b/src/serv_account/errors.rs
@@ -1,10 +1,12 @@
-use std::result::Result as StdResult;
+use reqwest::StatusCode;
+use ring::error::{KeyRejected, Unspecified};
+use std::{io, path::PathBuf, result::Result as StdResult};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum ServiceAccountError {
-    #[error("failed to read key file: {0}")]
-    ReadKey(String),
+    #[error("failed to read key file: {0}: {1}")]
+    ReadKey(PathBuf, io::Error),
 
     #[error("failed to de/serialize to json")]
     SerdeJson(#[from] serde_json::Error),
@@ -13,13 +15,22 @@ pub enum ServiceAccountError {
     Base64Decode(#[from] base64::DecodeError),
 
     #[error("failed to create rsa key pair: {0}")]
-    RsaKeyPair(String),
+    RsaKeyPair(KeyRejected),
 
     #[error("failed to rsa sign: {0}")]
-    RsaSign(String),
+    RsaSign(Unspecified),
 
     #[error("failed to send request")]
-    HttpReqwest(#[from] reqwest::Error),
+    HttpRequest(reqwest::Error),
+
+    #[error("failed to send request")]
+    HttpRequestUnsuccessful(StatusCode, std::result::Result<String, reqwest::Error>),
+
+    #[error("failed to get response JSON")]
+    HttpJson(reqwest::Error),
+
+    #[error("response returned non-Bearer auth access token: {0}")]
+    AccessTokenNotBeaarer(String),
 }
 
 pub type Result<T> = StdResult<T, ServiceAccountError>;

--- a/src/serv_account/errors.rs
+++ b/src/serv_account/errors.rs
@@ -30,7 +30,7 @@ pub enum ServiceAccountError {
     HttpJson(reqwest::Error),
 
     #[error("response returned non-Bearer auth access token: {0}")]
-    AccessTokenNotBeaarer(String),
+    AccessTokenNotBearer(String),
 }
 
 pub type Result<T> = StdResult<T, ServiceAccountError>;

--- a/src/serv_account/jwt.rs
+++ b/src/serv_account/jwt.rs
@@ -1,4 +1,4 @@
-use super::errors::{Result, ServiceAccountError};
+use super::errors::{GetAccessTokenError, ServiceAccountBuildError};
 use base64::{engine::general_purpose, Engine as _};
 use ring::{
     rand,
@@ -6,115 +6,115 @@ use ring::{
 };
 use serde_derive::Deserialize;
 use serde_derive::Serialize;
+use std::sync::Arc;
 
-#[derive(Debug)]
-pub struct JwtToken {
-    key_pair: RsaKeyPair,
-    header: JwtHeader,
-    payload: JwtPayload,
-}
-
-#[derive(Clone, Debug, Default, Serialize)]
-struct JwtHeader {
-    alg: String,
-    typ: String,
-}
-
-#[derive(Clone, Debug, Default, Serialize)]
-struct JwtPayload {
+#[derive(Debug, Clone)]
+pub struct JwtTokenSigner {
+    key_pair: Arc<RsaKeyPair>,
+    rng: rand::SystemRandom,
     iss: String,
     sub: Option<String>,
     scope: String,
     aud: String,
-    exp: u64,
-    iat: u64,
 }
 
-impl JwtToken {
+impl JwtTokenSigner {
     /// Creates a new JWT token from a service account key
-    pub fn from_key(key: &ServiceAccountKey) -> Result<Self> {
-        let iat = chrono::Utc::now().timestamp() as u64;
-        let exp = iat + 3600;
+    pub fn from_key(
+        key: ServiceAccountKey,
+        scope: String,
+        sub: Option<String>,
+    ) -> Result<Self, ServiceAccountBuildError> {
+        let no_whitespace = key.private_key.replace('\n', "");
+        let private_key = no_whitespace
+            .strip_prefix("-----BEGIN PRIVATE KEY-----")
+            .ok_or(ServiceAccountBuildError::RsaPrivateKeyNoPrefix)?
+            .strip_suffix("-----END PRIVATE KEY-----")
+            .ok_or(ServiceAccountBuildError::RsaPrivateKeyNoSuffix)?;
+        println!("private_key: {:?}", private_key);
 
-        let private_key = key
-            .private_key
-            .replace('\n', "")
-            .replace("-----BEGIN PRIVATE KEY-----", "")
-            .replace("-----END PRIVATE KEY-----", "");
-
-        let private_key = private_key.as_bytes();
-        let decoded = general_purpose::STANDARD.decode(private_key)?;
-        let key_pair = RsaKeyPair::from_pkcs8(&decoded).map_err(ServiceAccountError::RsaKeyPair)?;
+        let decoded = general_purpose::STANDARD
+            .decode(private_key.as_bytes())
+            .map_err(ServiceAccountBuildError::RsaPrivateKeyDecode)?;
+        let key_pair = RsaKeyPair::from_pkcs8(&decoded)
+            .map_err(ServiceAccountBuildError::RsaPrivateKeyParse)?;
 
         Ok(Self {
-            header: JwtHeader {
-                alg: String::from("RS256"),
-                typ: String::from("JWT"),
-            },
-            payload: JwtPayload {
-                iss: key.client_email.clone(),
-                sub: None,
-                scope: String::new(),
-                aud: key.token_uri.clone(),
-                exp,
-                iat,
-            },
-            key_pair,
+            iss: key.client_email,
+            rng: rand::SystemRandom::new(),
+            sub,
+            scope,
+            aud: key.token_uri,
+            key_pair: Arc::new(key_pair),
         })
     }
 
-    /// Returns a JWT token string
-    pub fn to_string(&self) -> Result<String> {
-        let header = serde_json::to_vec(&self.header)?;
-        let payload = serde_json::to_vec(&self.payload)?;
+    /// Returns a signed JWT token string
+    pub fn sign(&self) -> Result<String, GetAccessTokenError> {
+        #[derive(Clone, Debug, Default, Serialize)]
+        struct JwtHeader<'a> {
+            alg: &'a str,
+            typ: &'a str,
+        }
+        let header = serde_json::to_vec(&JwtHeader {
+            alg: "RS256",
+            typ: "JWT",
+        })
+        .map_err(GetAccessTokenError::JsonSerialization)?;
+        let header = general_purpose::STANDARD.encode(header);
 
-        let base64_header = general_purpose::STANDARD.encode(header);
-        let base64_payload = general_purpose::STANDARD.encode(payload);
+        #[derive(Clone, Debug, Default, Serialize)]
+        struct JwtPayload<'a> {
+            iss: &'a str,
+            sub: Option<&'a str>,
+            scope: &'a str,
+            aud: &'a str,
+            exp: u64,
+            iat: u64,
+        }
+        let iat = chrono::Utc::now().timestamp() as u64;
+        let exp = iat + 3600;
+        let payload = serde_json::to_vec(&JwtPayload {
+            iss: &self.iss,
+            sub: self.sub.as_deref(),
+            scope: &self.scope,
+            aud: &self.aud,
+            exp,
+            iat,
+        })
+        .map_err(GetAccessTokenError::JsonSerialization)?;
+        let payload = general_purpose::STANDARD.encode(payload);
 
-        let raw_signature = format!("{}.{}", base64_header, base64_payload);
-        let signature = self.sign_rsa(raw_signature)?;
+        let to_sign = format!("{header}.{payload}");
+        let signature =
+            sign_rsa(&self.key_pair, &self.rng, &to_sign).map_err(GetAccessTokenError::RsaSign)?;
+        let signature = general_purpose::STANDARD.encode(signature);
 
-        let base64_signature = general_purpose::STANDARD.encode(signature);
-
-        Ok(format!(
-            "{}.{}.{}",
-            base64_header, base64_payload, base64_signature
-        ))
+        Ok(format!("{to_sign}.{signature}"))
     }
 
     /// Returns the token uri
     pub fn token_uri(&self) -> &str {
-        &self.payload.aud
+        &self.aud
     }
+}
 
-    /// Sets the sub field in the payload
-    pub fn sub(mut self, sub: String) -> Self {
-        self.payload.sub = Some(sub);
-        self
-    }
+/// Signs a message with the private key
+fn sign_rsa(
+    key_pair: &RsaKeyPair,
+    rng: &dyn rand::SecureRandom,
+    message: &str,
+) -> Result<Vec<u8>, ring::error::Unspecified> {
+    // Sign the message, using PKCS#1 v1.5 padding and the SHA256 digest algorithm.
+    let mut signature = vec![0; key_pair.public_modulus_len()];
+    key_pair.sign(
+        &signature::RSA_PKCS1_SHA256,
+        rng,
+        message.as_bytes(),
+        &mut signature,
+    )?;
 
-    /// Sets the scope field in the payload
-    pub fn scope(mut self, scope: String) -> Self {
-        self.payload.scope = scope;
-        self
-    }
-
-    /// Signs a message with the private key
-    fn sign_rsa(&self, message: String) -> Result<Vec<u8>> {
-        // Sign the message, using PKCS#1 v1.5 padding and the SHA256 digest algorithm.
-        let rng = rand::SystemRandom::new();
-        let mut signature = vec![0; self.key_pair.public_modulus_len()];
-        self.key_pair
-            .sign(
-                &signature::RSA_PKCS1_SHA256,
-                &rng,
-                message.as_bytes(),
-                &mut signature,
-            )
-            .map_err(ServiceAccountError::RsaSign)?;
-
-        Ok(signature)
-    }
+    Ok(signature)
 }
 
 #[allow(dead_code)]
@@ -136,6 +136,7 @@ pub struct ServiceAccountKey {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::Value;
 
     fn read_key() -> ServiceAccountKey {
         serde_json::from_slice(include_bytes!(
@@ -145,49 +146,64 @@ mod tests {
     }
 
     #[test]
-    fn test_jwt_token() {
-        let mut token = JwtToken::from_key(&read_key()).unwrap();
-
-        assert_eq!(token.header.alg, "RS256");
-        assert_eq!(token.header.typ, "JWT");
-        assert!(token.payload.iss.contains("iam.gserviceaccount.com"));
-        assert_eq!(token.payload.sub, None);
-        assert_eq!(token.payload.scope, "");
-        assert_eq!(token.payload.aud, "https://oauth2.googleapis.com/token");
-        assert!(token.payload.exp > 0);
-        assert_eq!(token.payload.iat, token.payload.exp - 3600);
-
-        token = token
-            .sub(String::from("some@email.domain"))
-            .scope(String::from("test_scope1 test_scope2 test_scope3"));
-
-        assert_eq!(token.payload.sub, Some(String::from("some@email.domain")));
-        assert_eq!(token.payload.scope, "test_scope1 test_scope2 test_scope3");
-    }
-
-    #[test]
-    fn test_sign_rsa() {
-        let message = String::from("hello, world");
-
-        let token = JwtToken::from_key(&read_key()).unwrap();
-        let signature = token.sign_rsa(message).unwrap();
-
+    fn test_rsa_sign() {
+        let key = "MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCr/KzFiWfiw5vd8KrFPmsktUfmba4x8r0uPDxxdeI/zrENHPkef3Zd3Tt4bvdG4VRWAQ/zuomHcksTW1AYaaS/TfoiH5c/xivWptKHGS/eh91SgPunmoK9wbvdNW8C4goVdw57JUz6IG1vZpenHjI7ofHMfg+2cBiTsTSWFDnd1EoNkK2lmdP1R5lzxNSRce9HgugKvHAcvDtB2goL9coo8y+3kyBTiS5qCgpWplGwIMBACGW6U4a//GajvmvvZyfym7OXJeqjXznjNH32ghhjcP2DUuGf36wika1rOpmZKCJDKBoMPQERUDa1ydYLfY3v1g/8xFTL4ezuyYEkGuu5AgMBAAECggEAP3Meglno+53SuRR6y/31JTvD5Nz98Otuo8oROoKVD5k/dGkF9xxrHMHrmMjHbVzf8kK+Edr1tgSScfe0Gu2OnA02hLRG5n5D2hL9hF3kbSKOokt3jCPSrBL3Leryo4uk0Lp1mzTtqzGfbgPZWwwm2B0syZaQUWwVhRdRITUhDBcUW8cuxGXzNeDTJMUjij0li61H62rJFjE5nyxCpwlukqR96uVWN6wXhM4xhzwhaHt6oGVUAENG3Er+ZjYCgBISQkEuiaFUgB3Zkv3qYWhaWNhwhO6MDsT33xex4Ecw4epCrAfEirkP1AIYmVWFw3uxODOJ/u8mb6IQIobnxwRiIQKBgQDihX+XxV8tSvHxgHTN5vzp4oOgnKhmiClm7/MSbjwHjLcffWh6gqBLbPAvcrfA0aewIT29xgIO0CpygJcg/4RND30YKTilYo7/ieTkdwRYsCbt9zM/WBop1snZja4Zox/SK23u4OJ4uUw0e4onXOOzAogCtiEKMx+U6+JmsyhNFQKBgQDCXmAhdrinbfXtsC5J+HwC81XaFujE2l4EiLqVaHH6DIrVTNSucf6O/nsCHWhttb3U7xT7CIHCe1om8peKZsjuiQqmlKjeqPRhDNlLXV5TadIKUs8svPM+MUXArhTc3vAv1pArhi7RpQ5F1AeTJGkOvxcY6vmMjXIb/dSiZMp1FQKBgDIii+fidjtHEB98Z92+lxGI4cslgRwYXNl8mBbnMQAWw90DW6Fp0eJ/vPUzdboGbQ/Ne6XJ8mCm8A4hqdFS3ExV9kDntrLcCnxCX9e1A9BBRIx8nuoRLNE/ybMN6Y+hDATvOciaG2XO1S/0e9JUe8z97W50MwHX6NCEGLrUQkI1AoGADD4lj/YKa4FhnDccs0wTg5wQLEyFHOEkSuTR29dYVoeztvu/6b0Ea71bwiZYDZEFBASLLcS7Z6SdaRaetPkEbwHyyctTV7MMsZA9n6Gh718a+8t7gTXlnGU+H4TXi5H/TwQU0KkDCfF7lKpmT75bX7Jpoggq7895AIpcel4e4oECgYAbddARaP5mH2KAiSoBUlvh4P2beCv5HmWjIhS2nA7KaGOtGfOk9/VGTRLZXtPed70cGD5SrgMze3umI37nAtcVv+MHcZSXhjoSQZ6M3GChaDUwJNC+f6GVjfadn7LOsY5L1+0cu1pe6r4uXBOwmvv1tynpY6sGOE+tPJibK5Pm8Q==";
+        let key_pair = RsaKeyPair::from_pkcs8(&general_purpose::STANDARD.decode(key).unwrap())
+            .expect("Failed to parse key");
+        let rng = rand::SystemRandom::new();
+        let message = "hello world";
+        let signature = sign_rsa(&key_pair, &rng, message).unwrap();
         assert_eq!(signature.len(), 256);
     }
 
     #[test]
-    fn test_token_to_string() {
-        let token = JwtToken::from_key(&read_key())
-            .unwrap()
-            .sub(String::from("some@email.com"))
-            .scope(String::from("https://www.googleapis.com/auth/pubsub"));
+    fn test_sign() {
+        let scope = "test_scope1 test_scope2 test_scope3";
+        let signer = JwtTokenSigner::from_key(read_key(), scope.to_owned(), None).unwrap();
+        let token = signer.sign().unwrap();
+        println!("token: {:?}", token);
+        let parts = token.split('.').collect::<Vec<&str>>();
+        assert_eq!(parts.len(), 3);
+        let mut parts = parts.into_iter();
 
-        let token_string = token.to_string();
+        let header = parts.next().unwrap();
+        let header = general_purpose::STANDARD.decode(header).unwrap();
+        let header = serde_json::from_slice::<Value>(&header).unwrap();
+        assert_eq!(header["alg"], "RS256");
+        assert_eq!(header["typ"], "JWT");
 
-        assert!(token_string.is_ok(), "token string successfully created");
-        assert!(
-            !token_string.unwrap().is_empty(),
-            "token string is not empty"
+        let payload = parts.next().unwrap();
+        let payload = general_purpose::STANDARD.decode(payload).unwrap();
+        let payload = serde_json::from_slice::<Value>(&payload).unwrap();
+        assert_eq!(payload["scope"], Value::String(scope.to_owned()));
+        assert_eq!(payload["sub"], Value::Null);
+        assert_eq!(payload["aud"], "https://oauth2.googleapis.com/token");
+        assert!(payload["exp"].as_i64().unwrap() > 0);
+        assert_eq!(
+            payload["iat"].as_i64().unwrap(),
+            payload["exp"].as_i64().unwrap() - 3600
         );
+
+        let signature = parts.next().unwrap();
+        let signature = general_purpose::STANDARD.decode(signature).unwrap();
+        assert_eq!(signature.len(), 256);
+    }
+
+    #[test]
+    fn test_sign_email() {
+        let sub = "some@email.domain";
+        let signer =
+            JwtTokenSigner::from_key(read_key(), "".to_owned(), Some(sub.to_owned())).unwrap();
+        let token = signer.sign().unwrap();
+        let parts = token.split('.').collect::<Vec<&str>>();
+        assert_eq!(parts.len(), 3);
+        let mut parts = parts.into_iter();
+
+        let _header = parts.next().unwrap();
+
+        let payload = parts.next().unwrap();
+        let payload = general_purpose::STANDARD.decode(payload).unwrap();
+        let payload = serde_json::from_slice::<Value>(&payload).unwrap();
+        assert_eq!(payload["sub"], Value::String(sub.to_owned()));
     }
 }

--- a/src/serv_account/mod.rs
+++ b/src/serv_account/mod.rs
@@ -1,50 +1,43 @@
-use chrono::Utc;
+use self::errors::ServiceAccountError;
+use chrono::{DateTime, Duration, Utc};
 use errors::Result;
 use reqwest::Client as HttpClient;
+use serde_derive::Deserialize;
+use std::{path::Path, sync::Arc};
+use tokio::sync::RwLock;
 
-use self::errors::ServiceAccountError;
+pub use self::jwt::ServiceAccountKey;
 
-pub(crate) mod errors;
+pub mod errors;
 mod jwt;
 
 #[derive(Debug, Clone)]
 pub struct ServiceAccount {
-    scopes: String,
-    key_path: String,
-    user_email: Option<String>,
-
-    access_token: Option<String>,
-    expires_at: Option<u64>,
-
     http_client: HttpClient,
+    key: ServiceAccountKey,
+    scopes: String,
+    user_email: Option<String>,
+    access_token: Arc<RwLock<Option<AccessToken>>>,
 }
 
-#[derive(Debug, serde_derive::Deserialize)]
-struct Token {
-    access_token: String,
-    expires_in: u64,
-    token_type: String,
-}
-
-impl Token {
-    fn bearer_token(&self) -> String {
-        format!("{} {}", self.token_type, self.access_token)
-    }
+#[derive(Debug, Clone)]
+pub struct AccessToken {
+    pub bearer_token: String,
+    pub expires_at: DateTime<Utc>,
 }
 
 impl ServiceAccount {
+    pub fn builder() -> ServiceAccountBuilder {
+        ServiceAccountBuilder::new()
+    }
+
     /// Creates a new service account from a key file and scopes
-    pub fn from_file(key_path: &str, scopes: Vec<&str>) -> Self {
-        Self {
-            scopes: scopes.join(" "),
-            key_path: key_path.to_string(),
-            user_email: None,
-
-            access_token: None,
-            expires_at: None,
-
-            http_client: HttpClient::new(),
-        }
+    pub fn from_file<P: AsRef<Path>>(key_path: P, scopes: Vec<&str>) -> Result<Self> {
+        let bytes = std::fs::read(&key_path)
+            .map_err(|e| ServiceAccountError::ReadKey(key_path.as_ref().to_path_buf(), e))?;
+        let key = serde_json::from_slice::<ServiceAccountKey>(&bytes)
+            .map_err(ServiceAccountError::SerdeJson)?;
+        Ok(Self::builder().key(key).scopes(scopes).build())
     }
 
     /// Sets the user email
@@ -56,60 +49,125 @@ impl ServiceAccount {
     /// Returns an access token
     /// If the access token is not expired, it will return the cached access token
     /// Otherwise, it will exchange the JWT token for an access token
-    pub async fn access_token(&mut self) -> Result<String> {
-        match (self.access_token.as_ref(), self.expires_at) {
-            (Some(access_token), Some(expires_at))
-                if expires_at > Utc::now().timestamp() as u64 =>
-            {
-                Ok(access_token.to_string())
-            }
+    pub async fn access_token(&self) -> Result<AccessToken> {
+        let access_token = self.access_token.read().await.clone();
+        match access_token {
+            Some(access_token) if access_token.expires_at > Utc::now() => Ok(access_token),
             _ => {
-                let jwt_token = self.jwt_token()?;
-                let token = match self.exchange_jwt_token_for_access_token(jwt_token).await {
-                    Ok(token) => token,
-                    Err(err) => return Err(err),
-                };
-
-                let expires_at = Utc::now().timestamp() as u64 + token.expires_in - 30;
-
-                self.access_token = Some(token.bearer_token());
-                self.expires_at = Some(expires_at);
-
-                Ok(token.bearer_token())
+                let new_token = self.get_fresh_access_token().await?;
+                *self.access_token.write().await = Some(new_token.clone());
+                Ok(new_token)
             }
         }
     }
 
-    async fn exchange_jwt_token_for_access_token(
-        &mut self,
-        jwt_token: jwt::JwtToken,
-    ) -> Result<Token> {
-        let req_builder = self.http_client.post(jwt_token.token_uri()).form(&[
-            ("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer"),
-            ("assertion", &jwt_token.to_string()?),
-        ]);
-
-        let res = match req_builder.send().await {
-            Ok(resp) => resp,
-            Err(err) => return Err(ServiceAccountError::HttpReqwest(err)),
+    async fn get_fresh_access_token(&self) -> Result<AccessToken> {
+        let jwt_token = {
+            let mut token = jwt::JwtToken::from_key(&self.key)?.scope(self.scopes.clone());
+            if let Some(user_email) = &self.user_email {
+                token = token.sub(user_email.clone());
+            };
+            token
         };
 
-        let token = match res.json::<Token>().await {
-            Ok(token) => token,
-            Err(err) => return Err(ServiceAccountError::HttpReqwest(err)),
-        };
+        #[derive(Debug, Deserialize)]
+        pub struct TokenResponse {
+            token_type: String,
+            access_token: String,
+            expires_in: i64,
+        }
 
-        Ok(token)
+        let response = self
+            .http_client
+            .post(jwt_token.token_uri())
+            .form(&[
+                ("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer"),
+                ("assertion", &jwt_token.to_string()?),
+            ])
+            .send()
+            .await
+            .map_err(ServiceAccountError::HttpRequest)?;
+
+        if !response.status().is_success() {
+            return Err(ServiceAccountError::HttpRequestUnsuccessful(
+                response.status(),
+                response.text().await,
+            ));
+        }
+
+        let json = response
+            .json::<TokenResponse>()
+            .await
+            .map_err(ServiceAccountError::HttpJson)?;
+
+        if json.token_type != "Bearer" {
+            return Err(ServiceAccountError::AccessTokenNotBeaarer(json.token_type));
+        }
+
+        // Account for clock skew or time to receive or process the response
+        const LEEWAY: Duration = Duration::seconds(30);
+
+        let expires_at = Utc::now() + Duration::seconds(json.expires_in) - LEEWAY;
+
+        Ok(AccessToken {
+            bearer_token: json.access_token,
+            expires_at,
+        })
+    }
+}
+
+pub struct ServiceAccountBuilder {
+    http_client: Option<HttpClient>,
+    key: Option<ServiceAccountKey>,
+    scopes: Option<String>,
+    user_email: Option<String>,
+}
+
+impl ServiceAccountBuilder {
+    pub fn new() -> Self {
+        Self {
+            http_client: None,
+            key: None,
+            scopes: None,
+            user_email: None,
+        }
     }
 
-    fn jwt_token(&self) -> Result<jwt::JwtToken> {
-        let token = jwt::JwtToken::from_file(&self.key_path)?;
-
-        Ok(match self.user_email {
-            Some(ref user_email) => token.sub(user_email.to_string()),
-            None => token,
+    /// Panics if key is not provided
+    pub fn build(self) -> ServiceAccount {
+        ServiceAccount {
+            http_client: self.http_client.unwrap_or_default(),
+            key: self.key.expect("Key required"),
+            scopes: self.scopes.unwrap_or_default(),
+            user_email: self.user_email,
+            access_token: Arc::new(RwLock::new(None)),
         }
-        .scope(self.scopes.clone()))
+    }
+
+    pub fn http_client(mut self, http_client: HttpClient) -> Self {
+        self.http_client = Some(http_client);
+        self
+    }
+
+    pub fn key(mut self, key: ServiceAccountKey) -> Self {
+        self.key = Some(key);
+        self
+    }
+
+    pub fn scopes(mut self, scopes: Vec<&str>) -> Self {
+        self.scopes = Some(scopes.join(" "));
+        self
+    }
+
+    pub fn user_email<S: Into<String>>(mut self, user_email: S) -> Self {
+        self.user_email = Some(user_email.into());
+        self
+    }
+}
+
+impl Default for ServiceAccountBuilder {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -121,22 +179,26 @@ mod tests {
     async fn test_access_token() {
         let scopes = vec!["https://www.googleapis.com/auth/drive"];
         let key_path = "test_fixtures/service-account-key.json";
-        let mut service_account = ServiceAccount::from_file(key_path, scopes);
+        let service_account = ServiceAccount::from_file(key_path, scopes).unwrap();
 
         // TODO: fix this test - make sure we can run an integration test
         // let access_token = service_account.access_token();
         // assert!(access_token.is_ok());
         // assert!(!access_token.unwrap().is_empty());
 
-        service_account.access_token = Some("test_access_token".to_string());
-
-        let expires_at = Utc::now().timestamp() as u64 + 3600;
-        service_account.expires_at = Some(expires_at);
+        let expires_at = Utc::now() + Duration::seconds(3600);
+        *service_account.access_token.write().await = Some(AccessToken {
+            bearer_token: "test_access_token".to_string(),
+            expires_at,
+        });
 
         assert_eq!(
-            service_account.access_token().await.unwrap(),
+            service_account.access_token().await.unwrap().bearer_token,
             "test_access_token"
         );
-        assert_eq!(service_account.expires_at.unwrap(), expires_at);
+        assert_eq!(
+            service_account.access_token().await.unwrap().expires_at,
+            expires_at
+        );
     }
 }

--- a/src/serv_account/mod.rs
+++ b/src/serv_account/mod.rs
@@ -101,7 +101,7 @@ impl ServiceAccount {
             .map_err(ServiceAccountError::HttpJson)?;
 
         if json.token_type != "Bearer" {
-            return Err(ServiceAccountError::AccessTokenNotBeaarer(json.token_type));
+            return Err(ServiceAccountError::AccessTokenNotBearer(json.token_type));
         }
 
         // Account for clock skew or time to receive or process the response

--- a/src/token_provider/errors.rs
+++ b/src/token_provider/errors.rs
@@ -3,7 +3,7 @@ use thiserror::Error;
 use tokio::sync::mpsc::error::SendError;
 use tokio::sync::TryLockError;
 
-use crate::serv_account::errors::ServiceAccountError;
+use crate::serv_account::errors::GetAccessTokenError;
 
 #[derive(Debug, Error)]
 pub enum TokenProviderError {
@@ -11,7 +11,7 @@ pub enum TokenProviderError {
     AccessToken(#[from] TryLockError),
 
     #[error("service account error: {0}")]
-    ServiceAccountError(#[from] ServiceAccountError),
+    GetAccessTokenError(#[from] GetAccessTokenError),
 
     #[error("failed to send token: {0}")]
     SendError(#[from] SendError<String>),


### PR DESCRIPTION
This adds support for constructing a `ServiceAccount` directly from a `ServiceAccountKey`, rather than from a file. It also:
- Adds interior mutability using a tokio `RwLock` to enable cloning `ServiceAccount` while re-using the current access token across threads/instances. Also allows `ServiceAccount` to be used without needing to be `mut`.
- Makes `ServiceAccountKey` and its fields public to allow parsing or constructing the struct from any source (e.g. string, bytes, etc.) and also allows the fields inside to be re-used by other modules (e.g. reading `project_id` necessary for FCM)
- Adds `ServiceAccountBuilder` to enable the use of a variety of constructors, including the ability to re-use `reqwest::Client` across instantiations which enables sharing connection pools. Existing `from_file()` and `user_email()` methods continue to work for backwards-compatibility, but the builder pattern is generally a better alternative
- `access_token()` now returns `AccessToken` instead of e.g. `"Bearer token"` which allows the use of reqwest's `.bearer_token()` method without needing to parse-out the token. Also enables the invoker to see when the token will expire.
- Asserts that the returned token is indeed a bearer token
- `from_file()` retained as a helper method and now returns a `Result` type since file reading and parsing is performed in this function, rather than lazily in `access_token()`. Also now accepts any path-compatible value, rather than just `&str`.
- Stores `RsaKeyPair` in `JwtToken` rather than inputs to improve efficiency
- Catch and re-throw any non-200 status codes when requesting an access token. Also generally improve error handling by returning the original error, rather than converting into a string.
- Resolves various clippy errors

Resolves #28 