### PR TITLE
Bump ring to 0.17.14, gauth to 0.10.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "HTTP Client for Google OAuth2"
 name = "gauth"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Simon Makarski <code@makarski.dev>"]
 edition = "2024"
 rust-version = "1.85"
@@ -21,7 +21,7 @@ dirs = "5.0.1"
 reqwest = { version = "0.11", features = ["json"] }
 chrono = "0.4.31"
 base64 = "0.21.3"
-ring = "0.16.20"
+ring = "0.17.14"
 thiserror = "1.0.48"
 anyhow = "1.0.40"
 futures = { version = "0.3", features = ["executor"], optional = true }

--- a/examples/async_token_provider.rs
+++ b/examples/async_token_provider.rs
@@ -1,5 +1,5 @@
 //! `RUST_LOG=DEBUG cargo run --example async_token_provider --features token-watcher path/to/service-account-key.json` to run the example
-use tokio::time::{sleep, Duration};
+use tokio::time::{Duration, sleep};
 
 use gauth::serv_account::ServiceAccount;
 use gauth::token_provider::AsyncTokenProvider;

--- a/src/serv_account/jwt.rs
+++ b/src/serv_account/jwt.rs
@@ -114,7 +114,7 @@ impl JwtToken {
 
         // Sign the message, using PKCS#1 v1.5 padding and the SHA256 digest algorithm.
         let rng = rand::SystemRandom::new();
-        let mut signature = vec![0; key_pair.public_modulus_len()];
+        let mut signature = vec![0; key_pair.public().modulus_len()];
         key_pair
             .sign(
                 &signature::RSA_PKCS1_SHA256,

--- a/src/token_provider/errors.rs
+++ b/src/token_provider/errors.rs
@@ -1,7 +1,7 @@
 use std::result::Result as StdResult;
 use thiserror::Error;
-use tokio::sync::mpsc::error::SendError;
 use tokio::sync::TryLockError;
+use tokio::sync::mpsc::error::SendError;
 
 use crate::serv_account::errors::ServiceAccountError;
 

--- a/src/token_provider/mod.rs
+++ b/src/token_provider/mod.rs
@@ -1,8 +1,8 @@
 use async_trait::async_trait;
 use std::sync::Arc;
-use tokio::sync::mpsc::Sender;
 use tokio::sync::Mutex;
-use tokio::time::{interval, sleep, Duration};
+use tokio::sync::mpsc::Sender;
+use tokio::time::{Duration, interval, sleep};
 
 use self::errors::Result;
 


### PR DESCRIPTION
Closes the [GHSA-4p46-pwfr-66x6](https://github.com/advisories/GHSA-4p46-pwfr-66x6) advisory (`ring < 0.17.12` may panic in some AES paths when overflow checks are enabled). Gauth's public API is unchanged.

## What

- `ring` `0.16.20 → 0.17.14`
- `gauth` `0.9.0 → 0.10.0` (minor, to flag the cryptography dep bump even though there's no API break)
- API migration in `JwtToken::sign_rsa`: `public_modulus_len()` is deprecated in ring 0.17 — replaced with `public().modulus_len()`.
- `cargo fmt` reordered imports in a few files.

## Files

| File | Change |
|---|---|
| `Cargo.toml` | ring + gauth version bumps |
| `src/serv_account/jwt.rs` | migrate to `public().modulus_len()` |
| `examples/async_token_provider.rs`, `src/token_provider/{mod,errors}.rs` | import-order fmt only |

## Verification

- `cargo test --all-features`: **22 pass**, 1 pre-existing failure (`app::tests::test_access_token_success`: `Cannot start a runtime from within a runtime` — verified to exist on `main` before this branch; not introduced here, filed separately).
- `cargo clippy --all-features`: clean except a pre-existing dead-code warning on `OauthCredentials` fields.
- CodeScene pre-commit safeguard + change-set gates: both pass.

## Downstream

Once this is published to crates.io, `makarski/mstream` bumps its `gauth` dep to `0.10` to close one of the open dependabot alerts on that repo.