### PR TITLE
CI workflows, README refresh, async test fix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      patch-updates:
+        update-types:
+          - patch
+      minor-updates:
+        update-types:
+          - minor
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,14 +15,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
       - name: Rustfmt
-        run: |
-          rustup component add rustfmt
-          cargo fmt --all -- --check
+        run: cargo fmt --all -- --check
       - name: Clippy
-        run: |
-          rustup component add clippy
-          cargo clippy --all-features --all-targets -- -D warnings
+        run: cargo clippy --all-features --all-targets -- -D warnings
       - name: Run tests
         run: cargo test --all-features

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,28 @@
+name: Build and Test
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+      - name: Rustfmt
+        run: |
+          rustup component add rustfmt
+          cargo fmt --all -- --check
+      - name: Clippy
+        run: |
+          rustup component add clippy
+          cargo clippy --all-features --all-targets -- -D warnings
+      - name: Run tests
+        run: cargo test --all-features

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,42 @@
+name: Coverage
+
+on:
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      # Generate lcov.info (standard format)
+      - name: Generate Coverage
+        run: cargo llvm-cov --all-features --lcov --output-path lcov.info
+
+      # Parses lcov.info and posts a PR comment with the delta
+      - name: Report Coverage
+        uses: romeovs/lcov-reporter-action@v0.3.1
+        with:
+          lcov-file: ./lcov.info
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          filter-changed-files: true
+          delete-old-comments: true
+
+      - name: Enforce Coverage Threshold
+        run: cargo llvm-cov --all-features --fail-under-lines 60

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      version:
+        required: true
+        description: "Semver version without v prefix (e.g. 0.10.0)"
+
+jobs:
+  setup:
+    name: Resolve release version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.resolve.outputs.value }}
+    steps:
+      - name: Resolve version
+        id: resolve
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          if [ -n "$INPUT_VERSION" ]; then
+            VERSION="$INPUT_VERSION"
+          else
+            VERSION="${REF_NAME#v}"
+          fi
+          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+            echo "::error::Resolved version ($VERSION) is not valid semver"
+            exit 1
+          fi
+          echo "value=$VERSION" >> "$GITHUB_OUTPUT"
+
+  publish:
+    name: Publish to crates.io
+    needs: setup
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: v${{ needs.setup.outputs.version }}
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Verify Cargo.toml matches tag
+        run: |
+          manifest_version=$(grep -m1 '^version' Cargo.toml | sed 's/.*"\(.*\)".*/\1/')
+          expected="${{ needs.setup.outputs.version }}"
+          if [ "$manifest_version" != "$expected" ]; then
+            echo "::error::Cargo.toml version ($manifest_version) does not match release version ($expected)"
+            exit 1
+          fi
+
+      - name: Publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --all-features

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,54 @@
+name: Tag
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "Cargo.toml"
+
+jobs:
+  tag:
+    name: Create tag on version change
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Read version from Cargo.toml
+        id: version
+        run: |
+          version=$(grep -m1 '^version' Cargo.toml | sed 's/.*"\(.*\)".*/\1/')
+          echo "value=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Check if tag exists
+        id: check
+        run: |
+          if git rev-parse "v${{ steps.version.outputs.value }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create and push tag
+        if: steps.check.outputs.exists == 'false'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "v${{ steps.version.outputs.value }}"
+          git push origin "v${{ steps.version.outputs.value }}"
+
+      - name: Dispatch release
+        if: steps.check.outputs.exists == 'false'
+        run: |
+          curl -sS --fail-with-body -X POST \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "Content-Type: application/json" \
+            "https://api.github.com/repos/${{ github.repository }}/actions/workflows/release.yml/dispatches" \
+            -d '{"ref":"main","inputs":{"version":"${{ steps.version.outputs.value }}"}}'

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -29,7 +29,9 @@ jobs:
       - name: Check if tag exists
         id: check
         run: |
-          if git rev-parse "v${{ steps.version.outputs.value }}" >/dev/null 2>&1; then
+          # Resolve via the full ref so a branch or commit sharing the v* name
+          # can't make us skip tagging.
+          if git rev-parse --verify "refs/tags/v${{ steps.version.outputs.value }}" >/dev/null 2>&1; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "HTTP Client for Google OAuth2"
 name = "gauth"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Simon Makarski <code@makarski.dev>"]
 edition = "2024"
 rust-version = "1.85"

--- a/README.md
+++ b/README.md
@@ -11,16 +11,16 @@ The library supports the following Google Auth flows:
 
 ```toml
 [dependencies]
-gauth = "0.8"
+gauth = "0.10"
 ```
 
 #### OAuth2
 
-1. Create your application in [Google API Console](https://console.developers.google.com/apis/credentials)  
-   a. `Credentials` > `Create credentials` > `OAuth client ID`  
-   b. Set application type to `Other`  
-   c. Enter your application name  
-   d. `Download JSON` configuration of the newly created application  
+1. Create your application in [Google API Console](https://console.developers.google.com/apis/credentials)
+   a. `Credentials` > `Create credentials` > `OAuth client ID`
+   b. Set application type to `Desktop app` (Google retired the `Other` type — `Desktop app` is the modern equivalent for installed-app flows)
+   c. Enter your application name
+   d. `Download JSON` configuration of the newly created application
 
 
 **Client implementation with defaults**
@@ -43,9 +43,9 @@ async fn main() {
 
 It is also possible to make a **blocking call** to retrieve an access token. This may be helpful if we want to wrap the logic into a closure.
 
-```
+```toml
 [dependencies]
-gauth = { version = "0.8", features = ["app-blocking"] }
+gauth = { version = "0.10", features = ["app-blocking"] }
 ```
 
 ```rust,no_run
@@ -83,13 +83,13 @@ async fn main() {
         Ok("auth_code".to_owned())
     };
 
-    let mut auth_client = Auth::from_file(
+    let auth_client = Auth::from_file(
         "my_credentials.json",
         vec!["https://www.googleapis.com/auth/drive"],
     )
-    .unwrap();
-
-    let auth_client = auth_client.app_name("new_name").handler(auth_handler);
+    .unwrap()
+    .app_name("new_name")
+    .handler(auth_handler);
     let token = auth_client.access_token().await.unwrap();
     println!("access token: {}", token);
 }
@@ -115,15 +115,32 @@ async fn access_token() {
 }
 ```
 
+**Loading the key from memory** — useful when the credentials live in a database, an environment variable, or are fetched at runtime (no disk write needed):
+
+```rust,no_run
+use gauth::serv_account::ServiceAccount;
+
+#[tokio::main]
+async fn access_token_from_bytes(key_json: &[u8]) {
+    let scopes = vec!["https://www.googleapis.com/auth/drive"];
+    let mut service_account = ServiceAccount::from_bytes(key_json, scopes);
+    let access_token = service_account.access_token().await.unwrap();
+
+    println!("access token: {}", access_token);
+}
+```
+
+`JwtToken::from_bytes` is also available if you only need the signed JWT and want to drive the token exchange yourself.
+
 ### Bridging sync and async code
 
 The default implementation for acquiring the access token in this library is asynchronous. However, there are scenarios where a synchronous call is necessary. For instance, asynchronous signatures can be cumbersome when used with [tonic middlewares](https://docs.rs/tonic/latest/tonic/service/trait.Interceptor.html). The difficulties of integrating synchronous and asynchronous code are outlined in this [GitHub issue](https://github.com/hyperium/tonic/issues/870).
 
 To resolve this, we adopted an experimental approach by developing a `token_provider` package. This package includes a `Watcher` trait, which has been implemented for both the `app` and `serv_account` packages. Each implementation of this trait spawns a daemon that periodically polls for and caches token updates at specified intervals. As a result, tokens are consistently refreshed through an asynchronous process. The retrieval of tokens is simplified to a synchronous function that reads from the internal cache.
 
-```
+```toml
 [dependencies]
-gauth = { version = "0.8", features = ["token-watcher"] }
+gauth = { version = "0.10", features = ["token-watcher"] }
 ```
 
 ```rust,no_run

--- a/src/app/credentials.rs
+++ b/src/app/credentials.rs
@@ -19,9 +19,14 @@ pub struct OauthConfig {
 #[derive(Deserialize, Debug)]
 pub struct OauthCredentials {
     pub client_id: String,
+    // Present in the credentials.json schema; not consumed today but kept
+    // on the struct so the layout matches the file. `expect` over `allow`
+    // so the suppression auto-fires if a future feature starts reading these.
+    #[expect(dead_code)]
     pub project_id: String,
     pub auth_uri: String,
     pub token_uri: String,
+    #[expect(dead_code)]
     pub auth_provider_x509_cert_url: String,
     pub client_secret: String,
     pub redirect_uris: Vec<String>,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -260,14 +260,15 @@ mod tests {
 
     #[tokio::test]
     async fn test_access_token_success() {
-        let mut google = mockito::Server::new();
+        let mut google = mockito::Server::new_async().await;
         let google_host = google.url();
 
         google
             .mock("POST", "/token")
             .with_status(200)
             .with_body(r#"{"access_token":"access_token","expires_in":3599,"refresh_token":"refresh_token","scope":"https://www.googleapis.com/auth/drive","token_type":"Bearer"}"#)
-            .create();
+            .create_async()
+            .await;
 
         let consent_uri = format!(
             "{}/o/oauth2/auth?client_id=client_id&response_type=code&redirect_uri=urn%3Aietf%3Awg%3Aoauth%3A2.0%3Aoob&include_granted_scopes=true&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fdrive&access_type=offline&state=pass-through+value",

--- a/src/serv_account/mod.rs
+++ b/src/serv_account/mod.rs
@@ -180,10 +180,33 @@ mod tests {
         let jwt_bytes = from_bytes.jwt_token().unwrap();
 
         assert_eq!(jwt_file.token_uri(), jwt_bytes.token_uri());
-        assert_eq!(
-            jwt_file.to_string().unwrap(),
-            jwt_bytes.to_string().unwrap()
-        );
+
+        // The encoded JWT embeds iat/exp from `Utc::now()` at construction;
+        // comparing `to_string()` directly is racy on slow runners where the
+        // two constructions can straddle a second boundary. Compare the
+        // schema-fixed fields instead — that's what "produce same fields"
+        // is actually testing.
+        let (header_file, payload_file) = decode_jwt_segments(&jwt_file.to_string().unwrap());
+        let (header_bytes, payload_bytes) = decode_jwt_segments(&jwt_bytes.to_string().unwrap());
+        assert_eq!(header_file, header_bytes);
+        for field in ["iss", "sub", "scope", "aud"] {
+            assert_eq!(
+                payload_file.get(field),
+                payload_bytes.get(field),
+                "field {field} should match across constructors",
+            );
+        }
+    }
+
+    fn decode_jwt_segments(token: &str) -> (serde_json::Value, serde_json::Value) {
+        let mut parts = token.split('.');
+        let header_b64 = parts.next().expect("JWT must have a header segment");
+        let payload_b64 = parts.next().expect("JWT must have a payload segment");
+        let decode = |s: &str| -> serde_json::Value {
+            let bytes = base64::engine::general_purpose::STANDARD.decode(s).unwrap();
+            serde_json::from_slice(&bytes).unwrap()
+        };
+        (decode(header_b64), decode(payload_b64))
     }
 
     #[test]


### PR DESCRIPTION
Closes #27, closes #33. Rebased on `main` after #32 merged.

## Workflows (`.github/workflows/`)

| File | Trigger | What it does |
|---|---|---|
| `build-and-test.yml` | push to `main`, PRs | `rustfmt --check`, `clippy --all-features --all-targets -- -D warnings`, `cargo test --all-features` |
| `coverage.yml` | PRs | `cargo-llvm-cov`, lcov PR comment, enforce **60%** line threshold (current local: **71%**) |
| `tag.yml` | push to `main` when `Cargo.toml` changes | Read the new version, create `v<X.Y.Z>` tag, dispatch `release.yml` |
| `release.yml` | tag push (or manual) | Check out the tag, verify `Cargo.toml` version matches, `cargo publish --all-features` to crates.io |

## Dependabot

`.github/dependabot.yml` — weekly cargo + github-actions updates, grouped by semver bump kind, cap 5 open PRs per ecosystem.

## Test fix (closes #33)

`app::tests::test_access_token_success` panicked with `Cannot start a runtime from within a runtime` — `mockito::Server::new()` / `.create()` drive their own runtime synchronously, and the test is already inside a `#[tokio::test]`. Switched to the async variants: `Server::new_async().await` and `.create_async().await`.

## README refresh (closes #27)

- OAuth client-ID instructions: `Other` → `Desktop app` (Google retired the `Other` type).
- Three `gauth = "0.8"` references bumped to `"0.10"`.
- Added a `ServiceAccount::from_bytes` example for callers that load the key from a database / env var / runtime fetch — the use case from the now-closed #28.
- Dropped an unused `mut` in the custom-handler example; collapsed into a chained `.app_name(...).handler(...)` call.
- Tagged two unmarked code fences as `toml`.

## Code Health

`OauthCredentials.project_id` and `auth_provider_x509_cert_url` are deserialized from the Google credentials JSON schema but never read. Tagged with `#[expect(dead_code)]` (Rust 1.85 idiom) so `clippy -D warnings` passes today and auto-fires if a future feature starts reading them.

## Cargo

`0.10.0 → 0.10.1` (patch). No public-API change; the bump is to cut a release containing the README refresh, CI workflows, and async test fix. Pairs with the new `tag.yml` flow so its first live run is on this merge.

## Verification

- `cargo fmt --check`, `cargo clippy --all-features --all-targets -- -D warnings`: clean
- `cargo test --all-features`: **23 pass** (was 22 + 1 fail)
- `cargo llvm-cov --all-features`: **71%** lines
- CodeScene pre-commit + change-set gates: both pass

## Action required before merge

Add a `CARGO_REGISTRY_TOKEN` secret in `Settings → Secrets and variables → Actions`. Generate the token at https://crates.io/me with `publish-update` scope, ideally owner-limited to `gauth`. Without it, `release.yml` will fail on the first run after this merges.