### PR TITLE
0.10.2: dep bumps, atomic cache, test coverage, rustdoc

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,7 +13,7 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -31,7 +31,7 @@ jobs:
 
       # Parses lcov.info and posts a PR comment with the delta
       - name: Report Coverage
-        uses: romeovs/lcov-reporter-action@v0.3.1
+        uses: romeovs/lcov-reporter-action@v0.4.0
         with:
           lcov-file: ./lcov.info
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: v${{ needs.setup.outputs.version }}
 

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "HTTP Client for Google OAuth2"
 name = "gauth"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["Simon Makarski <code@makarski.dev>"]
 edition = "2024"
 rust-version = "1.85"
@@ -17,12 +17,12 @@ url = "^2.4.1"
 serde = "1"
 serde_json = "1"
 serde_derive = "1"
-dirs = "5.0.1"
-reqwest = { version = "0.11", features = ["json"] }
+dirs = "6"
+reqwest = { version = "0.13", features = ["json", "form"] }
 chrono = "0.4.31"
-base64 = "0.21.3"
+base64 = "0.22"
 ring = "0.17.14"
-thiserror = "1.0.48"
+thiserror = "2"
 anyhow = "1.0.40"
 futures = { version = "0.3", features = ["executor"], optional = true }
 tokio = { version = "1.33.0", optional = true }
@@ -31,7 +31,7 @@ log = { version = "0.4", optional = true }
 [dev-dependencies]
 mockito = "1.2.0"
 tokio = { version = "1.33.0", features = ["test-util", "macros", "rt-multi-thread"] }
-env_logger = "0.10.0"
+env_logger = "0.11"
 
 [features]
 app-blocking = ["dep:futures"]

--- a/src/app/credentials.rs
+++ b/src/app/credentials.rs
@@ -71,3 +71,78 @@ fn auth_code_uri(credentials: &OauthCredentials, scope: &str) -> Result<url::Url
     uri.query_pairs_mut().finish();
     Ok(uri)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    const FIXTURE: &str = "test_fixtures/oauth-credentials.json";
+
+    #[test]
+    fn read_oauth_config_parses_installed_app_schema() {
+        let cfg = read_oauth_config(Path::new(FIXTURE)).unwrap();
+        assert_eq!(
+            cfg.installed.client_id,
+            "test-client-id.apps.googleusercontent.com"
+        );
+        assert_eq!(cfg.installed.client_secret, "test-client-secret");
+        assert_eq!(
+            cfg.installed.token_uri,
+            "https://oauth2.googleapis.com/token"
+        );
+        assert_eq!(cfg.installed.redirect_uris.len(), 2);
+        assert_eq!(cfg.installed.redirect_uris[0], "urn:ietf:wg:oauth:2.0:oob");
+    }
+
+    #[test]
+    fn read_oauth_config_missing_file_errors() {
+        let err = read_oauth_config(Path::new("/no/such/file.json")).unwrap_err();
+        assert!(
+            matches!(err, AuthError::IOError(_)),
+            "expected IoError, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn redirect_uri_returns_first_when_present() {
+        let creds = OauthCredentials {
+            client_id: "id".into(),
+            project_id: "p".into(),
+            auth_uri: "https://example.com/auth".into(),
+            token_uri: "https://example.com/token".into(),
+            auth_provider_x509_cert_url: "https://example.com/certs".into(),
+            client_secret: "s".into(),
+            redirect_uris: vec!["http://localhost".into(), "http://other".into()],
+        };
+        assert_eq!(creds.redirect_uri().unwrap(), "http://localhost");
+    }
+
+    #[test]
+    fn redirect_uri_empty_errors() {
+        let creds = OauthCredentials {
+            client_id: "id".into(),
+            project_id: "p".into(),
+            auth_uri: "https://example.com/auth".into(),
+            token_uri: "https://example.com/token".into(),
+            auth_provider_x509_cert_url: "https://example.com/certs".into(),
+            client_secret: "s".into(),
+            redirect_uris: vec![],
+        };
+        assert!(matches!(
+            creds.redirect_uri().unwrap_err(),
+            AuthError::RedirectUriCfgError,
+        ));
+    }
+
+    #[test]
+    fn auth_code_uri_contains_scope_and_client_id() {
+        let cfg = read_oauth_config(Path::new(FIXTURE)).unwrap();
+        let uri =
+            auth_code_uri_str(&cfg.installed, "https://www.googleapis.com/auth/drive").unwrap();
+        assert!(uri.contains("client_id=test-client-id"));
+        assert!(uri.contains("scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fdrive"));
+        assert!(uri.contains("response_type=code"));
+        assert!(uri.contains("access_type=offline"));
+    }
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -273,14 +273,29 @@ impl Auth {
 
 static TMP_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
-/// Write `bytes` to `tmp_path` and atomically rename it to `final_path`.
+/// Write `bytes` to `tmp_path`, fsync, then atomically rename it to
+/// `final_path`.
 ///
 /// `rename` on the same filesystem is atomic, so a concurrent reader either
 /// sees the previous file contents or the new ones — never a half-written
-/// blob. If the write fails, the tmp file is best-effort removed so we don't
+/// blob. The `sync_all` call before the rename also defends against a
+/// power-loss / crash between write and rename: on filesystems with weak
+/// data-ordering (e.g. ext4 `data=writeback`) the rename's metadata can
+/// otherwise hit disk before the new file's data blocks, leaving
+/// `access_token.json` referencing a file with zero or partial data after
+/// reboot. The tmp file is best-effort removed on any failure so we don't
 /// leak `.tmp` files into the cache dir.
 fn write_then_rename(tmp_path: &PathBuf, final_path: &PathBuf, bytes: &[u8]) -> Result<()> {
-    if let Err(err) = std::fs::write(tmp_path, bytes) {
+    use std::io::Write;
+
+    let write_and_sync = || -> std::io::Result<()> {
+        let mut file = std::fs::File::create(tmp_path)?;
+        file.write_all(bytes)?;
+        file.sync_all()?;
+        Ok(())
+    };
+
+    if let Err(err) = write_and_sync() {
         let _ = std::fs::remove_file(tmp_path);
         return Err(err.into());
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,3 +1,13 @@
+//! OAuth2 for installed apps (three-legged consent flow).
+//!
+//! See [`Auth`] for the entry point. Construct via [`Auth::from_file`] with
+//! a Google API Console credentials JSON and a list of scopes, then call
+//! [`Auth::access_token`] to retrieve a bearer token. The first call walks
+//! the consent flow (either via the supplied [`AuthHandlerFn`] or the
+//! default `stdin` handler); subsequent calls reuse a cached refresh
+//! token. The token is cached on disk under `$HOME/.{app_name}/` (or
+//! `GAUTH_TOKEN_DIR` if set) and atomically replaced on refresh.
+
 use std::path::PathBuf;
 use std::result::Result as StdResult;
 use std::{env, path};
@@ -130,6 +140,12 @@ impl Auth {
             .map(|token| token.bearer_token())
     }
 
+    /// Synchronous wrapper around [`Self::access_token`], available under the
+    /// `app-blocking` feature. Drives the async call to completion via
+    /// `futures::executor::block_on` — useful when wiring gauth into a
+    /// synchronous integration point (e.g. a tonic interceptor or a sync
+    /// trait impl). Must not be called from inside a tokio runtime; for that
+    /// case, await [`Self::access_token`] directly.
     #[cfg(feature = "app-blocking")]
     pub fn access_token_blocking(&self) -> Result<String> {
         futures::executor::block_on(self.access_token())
@@ -210,7 +226,19 @@ impl Auth {
 
         let token_path = token_dir.join("access_token.json");
         let b = serde_json::to_vec(&token)?;
-        std::fs::write(token_path, b)?;
+
+        // Atomic write: serialise to a sibling tmp file, fsync, then rename.
+        // `rename` on the same filesystem is atomic, so concurrent refreshers
+        // can't observe a half-written `access_token.json`. PID + a process-
+        // local counter keeps the tmp path unique across both processes and
+        // threads.
+        let suffix = TMP_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let tmp_path = token_dir.join(format!(
+            "access_token.json.{}.{}.tmp",
+            std::process::id(),
+            suffix,
+        ));
+        write_then_rename(&tmp_path, &token_path, &b)?;
 
         Ok(token)
     }
@@ -241,6 +269,26 @@ impl Auth {
             Err(_) => false,
         }
     }
+}
+
+static TMP_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Write `bytes` to `tmp_path` and atomically rename it to `final_path`.
+///
+/// `rename` on the same filesystem is atomic, so a concurrent reader either
+/// sees the previous file contents or the new ones — never a half-written
+/// blob. If the write fails, the tmp file is best-effort removed so we don't
+/// leak `.tmp` files into the cache dir.
+fn write_then_rename(tmp_path: &PathBuf, final_path: &PathBuf, bytes: &[u8]) -> Result<()> {
+    if let Err(err) = std::fs::write(tmp_path, bytes) {
+        let _ = std::fs::remove_file(tmp_path);
+        return Err(err.into());
+    }
+    if let Err(err) = std::fs::rename(tmp_path, final_path) {
+        let _ = std::fs::remove_file(tmp_path);
+        return Err(err.into());
+    }
+    Ok(())
 }
 
 fn default_auth_handler(consent_uri: String) -> StdResult<String, AnyError> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,30 @@
+//! HTTP client for Google OAuth2.
+//!
+//! This crate covers two Google auth flows:
+//!
+//!   * [`app`] — **OAuth2 for installed apps**. Three-legged flow with a
+//!     consent URI, auth code exchange, and a refresh-token loop. Tokens are
+//!     cached on disk so subsequent calls reuse them until they expire.
+//!   * [`serv_account`] — **Service accounts**. JWT-bearer flow for
+//!     server-to-server auth using a Google-issued JSON key. Tokens are
+//!     cached in-memory on the [`ServiceAccount`] instance.
+//!
+//! ## Optional features
+//!
+//!   * `app-blocking` — adds [`app::Auth::access_token_blocking`], a
+//!     synchronous wrapper around the async access-token call. Useful when
+//!     plugging gauth into a synchronous integration point (e.g. a tonic
+//!     interceptor).
+//!   * `token-watcher` — adds [`token_provider::AsyncTokenProvider`], a
+//!     daemon that periodically refreshes a token in the background and
+//!     exposes a synchronous read accessor over a shared cache.
+//!
+//! See the crate README for usage examples.
+//!
+//! [`ServiceAccount`]: serv_account::ServiceAccount
+
+#![deny(missing_docs)]
+
 pub mod app;
 pub mod serv_account;
 

--- a/src/serv_account/mod.rs
+++ b/src/serv_account/mod.rs
@@ -1,3 +1,14 @@
+//! Service-account JWT-bearer flow for server-to-server auth.
+//!
+//! Construct a [`ServiceAccount`] from a Google-issued service account JSON
+//! key (via [`ServiceAccount::from_file`] for a path or
+//! [`ServiceAccount::from_bytes`] when the key is loaded from a database or
+//! environment variable), then call [`ServiceAccount::access_token`] to
+//! obtain a bearer token. Tokens are cached in memory on the instance and
+//! refreshed automatically before expiry. Optionally set
+//! [`ServiceAccount::user_email`] to impersonate a workspace user for
+//! domain-wide delegation.
+
 use chrono::Utc;
 use errors::Result;
 use reqwest::Client as HttpClient;
@@ -22,6 +33,12 @@ impl std::fmt::Debug for KeySource {
     }
 }
 
+/// Google service-account credentials with a cached access token.
+///
+/// Construct via [`Self::from_file`] or [`Self::from_bytes`], optionally
+/// chain [`Self::user_email`] to impersonate a workspace user, then call
+/// [`Self::access_token`] to retrieve a bearer token. The token is cached
+/// on the instance and refreshed automatically once it expires.
 #[derive(Debug, Clone)]
 pub struct ServiceAccount {
     scopes: String,

--- a/src/token_provider/mod.rs
+++ b/src/token_provider/mod.rs
@@ -1,3 +1,16 @@
+//! Background token refresher with a synchronous read accessor.
+//!
+//! Wrap any [`TokenProvider`] in an [`AsyncTokenProvider`] to spawn a daemon
+//! that calls `access_token` on the given interval, retries with
+//! exponential backoff on failure, and caches the latest value behind a
+//! [`tokio::sync::Mutex`]. Synchronous consumers (e.g. tonic interceptors)
+//! can read the cached token via [`AsyncTokenProvider::access_token`]
+//! without `.await`.
+//!
+//! `TokenProvider` is implemented for [`crate::serv_account::ServiceAccount`]
+//! and [`crate::app::Auth`] out of the box; downstream types can add their
+//! own impls.
+
 use async_trait::async_trait;
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -8,6 +21,8 @@ use self::errors::Result;
 
 mod errors;
 
+/// Background-refreshing token cache. See the [module-level docs](self) for
+/// the design and usage.
 #[derive(Debug, Clone)]
 pub struct AsyncTokenProvider<T> {
     inner: T,
@@ -15,8 +30,13 @@ pub struct AsyncTokenProvider<T> {
     interval: u64,
 }
 
+/// Anything that can produce a fresh access token. The blanket
+/// [`Watcher`] impl turns any `TokenProvider` into something that can drive
+/// the [`AsyncTokenProvider`] refresh loop.
 #[async_trait]
 pub trait TokenProvider: Send {
+    /// Produce a fresh access token, refreshing the underlying credential
+    /// state as needed. Called once per refresh interval by [`Watcher`].
     async fn access_token(&mut self) -> Result<String>;
 }
 
@@ -34,8 +54,14 @@ impl TokenProvider for crate::app::Auth {
     }
 }
 
+/// Drives a token-refresh loop and forwards each fresh value over a channel.
+/// A blanket impl is provided for every [`TokenProvider`], so consumers
+/// implement `TokenProvider` and get `Watcher` for free.
 #[async_trait]
 pub trait Watcher {
+    /// Refresh the token every `interval_sec` seconds, sending each value
+    /// down `tx`. On error the call is retried up to three times with
+    /// exponential backoff (2, 4, 8 seconds) before the loop exits.
     async fn watch_updates(&mut self, tx: Sender<String>, interval_sec: u64);
 }
 
@@ -80,6 +106,8 @@ impl<T> AsyncTokenProvider<T>
 where
     T: Watcher + Clone + Send + 'static,
 {
+    /// Create a new provider wrapping `inner`. Defaults to a 60-second
+    /// refresh interval; override with [`Self::with_interval`].
     pub fn new(inner: T) -> Self {
         Self {
             inner,
@@ -88,15 +116,24 @@ where
         }
     }
 
+    /// Override the refresh interval (in seconds) before starting
+    /// [`Self::watch_updates`].
     pub fn with_interval(mut self, interval: u64) -> Self {
         self.interval = interval;
         self
     }
 
+    /// Synchronous read of the cached token. Returns the empty string until
+    /// the first refresh completes. Fails with an `AccessToken` error if the
+    /// cache mutex is currently held by the refresh task — retry, or `await`
+    /// on a clone of the inner [`TokenProvider`] for guaranteed availability.
     pub fn access_token(&self) -> Result<String> {
         Ok(self.cached_token.try_lock()?.clone())
     }
 
+    /// Spawn the background refresh loop. Returns immediately; the spawned
+    /// tasks live until the inner [`Watcher`] gives up (after three
+    /// consecutive failed attempts) or the runtime shuts down.
     pub async fn watch_updates(&self) {
         let (tx, mut rx) = tokio::sync::mpsc::channel(1);
 
@@ -115,5 +152,117 @@ where
                 *cached_token = token;
             }
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    /// A fake `TokenProvider` that returns deterministic, counted tokens and
+    /// can be configured to fail a fixed number of initial calls so we can
+    /// exercise the retry path without touching the network.
+    #[derive(Clone)]
+    struct FakeProvider {
+        calls: Arc<AtomicU32>,
+        fail_first_n: u32,
+    }
+
+    impl FakeProvider {
+        fn new() -> Self {
+            Self {
+                calls: Arc::new(AtomicU32::new(0)),
+                fail_first_n: 0,
+            }
+        }
+
+        fn with_initial_failures(n: u32) -> Self {
+            Self {
+                calls: Arc::new(AtomicU32::new(0)),
+                fail_first_n: n,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl TokenProvider for FakeProvider {
+        async fn access_token(&mut self) -> Result<String> {
+            let call = self.calls.fetch_add(1, Ordering::SeqCst);
+            if call < self.fail_first_n {
+                Err(errors::TokenProviderError::SendError(
+                    tokio::sync::mpsc::error::SendError("simulated".to_string()),
+                ))
+            } else {
+                Ok(format!("tok-{}", call))
+            }
+        }
+    }
+
+    #[test]
+    fn new_defaults_to_sixty_second_interval() {
+        let provider = AsyncTokenProvider::new(FakeProvider::new());
+        assert_eq!(provider.interval, 60);
+    }
+
+    #[test]
+    fn with_interval_overrides_default() {
+        let provider = AsyncTokenProvider::new(FakeProvider::new()).with_interval(5);
+        assert_eq!(provider.interval, 5);
+    }
+
+    #[test]
+    fn access_token_returns_empty_string_initially() {
+        let provider = AsyncTokenProvider::new(FakeProvider::new());
+        assert_eq!(provider.access_token().unwrap(), "");
+    }
+
+    /// `watch_updates` populates the cache from the inner provider on the
+    /// first tick. Time is paused so the test doesn't sleep for real. We
+    /// only assert the cache is *some* `tok-N` value — under paused time
+    /// `interval.tick()` fires immediately, so multiple iterations can race
+    /// before we observe; the meaningful property is that the cache moves
+    /// from empty to populated.
+    #[tokio::test(start_paused = true)]
+    async fn watch_updates_populates_cache_from_provider() {
+        let provider = AsyncTokenProvider::new(FakeProvider::new()).with_interval(60);
+        provider.watch_updates().await;
+
+        for _ in 0..32 {
+            tokio::task::yield_now().await;
+            if let Ok(t) = provider.access_token()
+                && !t.is_empty()
+            {
+                assert!(t.starts_with("tok-"), "unexpected cached value: {t}");
+                return;
+            }
+        }
+        panic!("cache never populated within 32 yields");
+    }
+
+    /// The watcher retries on failure with exponential backoff and recovers
+    /// once the underlying provider starts succeeding. With
+    /// `fail_first_n = 2`, the third call onwards succeeds — the cache must
+    /// eventually populate. We don't pin the exact value for the same
+    /// paused-clock reason as the test above.
+    #[tokio::test(start_paused = true)]
+    async fn watch_updates_recovers_after_transient_failures() {
+        let provider = AsyncTokenProvider::new(FakeProvider::with_initial_failures(2));
+        provider.watch_updates().await;
+
+        // attempt 1 fails -> sleep 1<<1 = 2s
+        // attempt 2 fails -> sleep 1<<2 = 4s
+        // attempt 3 succeeds. 16 simulated seconds is generous headroom.
+        for _ in 0..16 {
+            tokio::time::advance(Duration::from_secs(1)).await;
+            tokio::task::yield_now().await;
+            if let Ok(t) = provider.access_token()
+                && !t.is_empty()
+            {
+                assert!(t.starts_with("tok-"), "unexpected cached value: {t}");
+                return;
+            }
+        }
+        panic!("cache never populated after 16 simulated seconds");
     }
 }

--- a/test_fixtures/oauth-credentials.json
+++ b/test_fixtures/oauth-credentials.json
@@ -1,0 +1,11 @@
+{
+  "installed": {
+    "client_id": "test-client-id.apps.googleusercontent.com",
+    "project_id": "test-project",
+    "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+    "token_uri": "https://oauth2.googleapis.com/token",
+    "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+    "client_secret": "test-client-secret",
+    "redirect_uris": ["urn:ietf:wg:oauth:2.0:oob", "http://localhost"]
+  }
+}


### PR DESCRIPTION
Folds the seven dependabot PRs (closed in favor of this) into one focused 0.10.2 release alongside three library improvements: atomic token-cache writes, test coverage for the two 0%-covered modules, and a full rustdoc pass with \`#![deny(missing_docs)]\` enforcement.

## Dep bumps

| From | To | Notes |
|---|---|---|
| reqwest 0.11 | 0.13 | **Default TLS backend changes from native-tls to rustls** (reqwest 0.13 default); removes the OpenSSL system dep. \`form\` is feature-gated in 0.13 so added explicitly. |
| base64 0.21 | 0.22 | Transparent at call sites. |
| dirs 5 | 6 | Transparent. |
| env_logger 0.10 | 0.11 | Transparent. |
| thiserror 1 | 2 | Transparent. |
| actions/checkout v4 | v6 | Across all four workflows. |
| romeovs/lcov-reporter-action v0.3.1 | v0.4.0 | Coverage workflow. |

## Atomic \`cache_token\`

\`Auth::cache_token\` previously did a direct \`std::fs::write\` of \`access_token.json\`, which left the file half-written if two refreshers raced or the writer was interrupted. Switched to a sibling tmp file (PID + per-process counter to keep the path unique) + atomic \`rename\`. Best-effort tmp cleanup on write failure so we don't leak \`.tmp\` files.

## Test coverage: 71% → 85% lines

| Module | Before | After |
|---|---|---|
| \`app/credentials.rs\` | **0%** | **100%** |
| \`token_provider/mod.rs\` | **0%** | **92%** |

- \`credentials.rs\`: added \`test_fixtures/oauth-credentials.json\` and 5 tests covering \`read_oauth_config\` (happy path + missing file), \`OauthCredentials::redirect_uri\` (first + empty), and \`auth_code_uri_str\` parameter shape.
- \`token_provider/mod.rs\`: a \`FakeProvider\` impl drives the \`Watcher\` loop under \`tokio::time::pause()\` so the daemon's tick + backoff paths run deterministically without sleeping for real. Covers the builder, sync read accessor, the happy refresh path, and recovery after transient failures.

## Rustdoc + \`#![deny(missing_docs)]\`

- Crate-level docs in \`lib.rs\` with a tour of the two modules + optional features.
- Module-level \`//!\` docs on \`app\`, \`serv_account\`, \`token_provider\`.
- \`///\` docs on every public item (\`Auth::access_token_blocking\`, \`ServiceAccount\`, \`AsyncTokenProvider\`, \`TokenProvider\`, \`Watcher\`, all builder methods).
- \`#![deny(missing_docs)]\` at lib root — future public additions must come with docs.

## Version

\`Cargo.toml\` \`0.10.1 → 0.10.2\`. \`tag.yml\` + \`release.yml\` fire on merge and publish to crates.io.

## Verification

- \`cargo fmt --check\`: clean
- \`cargo clippy --all-features --all-targets -- -D warnings\`: clean
- \`cargo test --all-features\`: **33 pass** (was 23)
- \`cargo doc -D missing_docs --all-features --no-deps\`: clean
- CodeScene pre-commit + change-set gates: both pass

## Closes

Closes #35, closes #36, closes #37, closes #38, closes #39, closes #40, closes #41.

## Action required

If \`CARGO_REGISTRY_TOKEN\` is in place from the 0.10.1 release, no further action — \`release.yml\` will auto-publish on merge.